### PR TITLE
Fix snippet generation in widgetconfig

### DIFF
--- a/widgetconfig.php
+++ b/widgetconfig.php
@@ -230,7 +230,7 @@ $snippet .= '<div class="symplissime-chat-widget" '
     function updateSnippet() {
         const data = new FormData(form);
         const autoOpen = data.get('auto_open') ? 'true' : 'false';
-        const snippet = `<script src="symplissime-widget.js"></script>\n` +
+        const snippet = '<script src="symplissime-widget.js"><\/script>\n' +
             `<div class="symplissime-chat-widget" data-api-endpoint="${data.get('api_endpoint')}" data-workspace="${data.get('workspace')}" data-title="${data.get('title')}" data-auto-open="${autoOpen}" data-position="${data.get('position')}" data-theme="${data.get('theme')}"></div>`;
         document.getElementById('snippet').value = snippet;
     }


### PR DESCRIPTION
## Summary
- Escape closing script tag in dynamic snippet to prevent syntax error in widgetconfig

## Testing
- `php -l widgetconfig.php`


------
https://chatgpt.com/codex/tasks/task_e_68af52d9988c832cac421075a2c6e05d