### PR TITLE
feat: improve configurator design with preview

### DIFF
--- a/widget_configurator.html
+++ b/widget_configurator.html
@@ -192,7 +192,7 @@
             <h1>Widget Symplissime AI Enhanced</h1>
             <p>Test des nouvelles fonctionnalités : thèmes, formes, positions et photos de profil</p>
             
-            <a href="configurateur-widget.php" class="config-link" target="_blank">
+            <a href="widgetconfig.php" class="config-link" target="_blank">
                 🛠️ Ouvrir le Configurateur
             </a>
         </div>
@@ -270,7 +270,7 @@
 📁 Fichiers requis :
 ├── symplissime-widget-enhanced.js  ← Widget avec toutes les options
 ├── symplissime-widget-api.php      ← Backend API (inchangé)
-└── configurateur-widget.php        ← Configurateur PHP
+└── widgetconfig.php                ← Configurateur PHP
             </div>
         </div>
 


### PR DESCRIPTION
## Summary
- enhance configurator admin UI with modern styling
- add live widget preview alongside snippet generation
- fix test page link to new configurator

## Testing
- `php -l widgetconfig.php`
- `npx --yes htmlhint widget_configurator.html` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68af5b4e589c832c86de1d326f20f299