### PR TITLE
Add quick replies configuration

### DIFF
--- a/symplissime-widget.js
+++ b/symplissime-widget.js
@@ -788,12 +788,15 @@
             const quickContainer = document.createElement('div');
             quickContainer.className = 'symplissime-quick-messages';
             
-            this.config.quickMessages.forEach(message => {
+            this.config.quickMessages.slice(0, 6).forEach(message => {
                 const btn = document.createElement('button');
                 btn.className = 'symplissime-quick-message';
                 btn.textContent = message;
                 btn.addEventListener('click', () => {
                     this.input.value = message;
+                    if (!this.isOpen) {
+                        this.openWidget();
+                    }
                     this.sendMessage();
                 });
                 quickContainer.appendChild(btn);

--- a/widget_config.json
+++ b/widget_config.json
@@ -5,6 +5,7 @@
     "title": "",
     "auto_open": false,
     "position": "bottom-right",
-    "theme": "symplissime"
+    "theme": "symplissime",
+    "quick_messages": []
   }
 }


### PR DESCRIPTION
## Summary
- add greetings tab to configure quick replies (up to six)
- include quick replies in generated snippet and preview
- ensure quick reply buttons open chat and send message

## Testing
- `php -l widgetconfig.php`
- `node --check symplissime-widget.js`


------
https://chatgpt.com/codex/tasks/task_e_68af5dd6bc08832ca18dc94faf532a35