### PR TITLE
feat: add default quick messages options

### DIFF
--- a/test.html
+++ b/test.html
@@ -237,12 +237,13 @@
 
     <!-- Widget de test -->
     <script src="symplissime-widget.js"></script>
-    <div class="symplissime-chat-widget" 
+    <div class="symplissime-chat-widget"
          data-api-endpoint="symplissime-widget-api.php"
          data-workspace="support-windows"
          data-title="Test Widget"
          data-subtitle="Widget de démonstration"
-         data-placeholder="Testez le widget...">
+         data-placeholder="Testez le widget..."
+         data-quick-messages="Qu'est-ce que Symplissime ?|Combien coûte Symplissime ?|A qui s'adresse Symplissime ?">
     </div>
 </body>
 </html>

--- a/widget_config.json
+++ b/widget_config.json
@@ -6,7 +6,7 @@
     "auto_open": false,
     "position": "bottom-right",
     "theme": "symplissime",
-    "quick_messages": ""
+    "quick_messages": "Qu'est-ce que Symplissime ?|Combien coûte Symplissime ?|A qui s'adresse Symplissime ?"
   },
   "greetings": {
     "welcome_message": "👋 **Bonjour !** Bienvenue chez Symplissime AI.\n\nComment puis-je vous aider aujourd'hui ?",


### PR DESCRIPTION
## Summary
- add default quick message options to widget configuration
- showcase quick messages in test HTML

## Testing
- `node - <<'NODE'...` (splits quick messages string into three entries)
- `npm install jsdom --no-save` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68af66b06070832c92e9971a987bf98f