### PR TITLE
Cleanup quick message container after selection

### DIFF
--- a/symplissime-widget.js
+++ b/symplissime-widget.js
@@ -826,7 +826,8 @@
         
         addQuickMessages() {
             if (this.config.quickMessages.length === 0) return;
-            
+            if (this.messages.querySelector('.symplissime-quick-messages')) return;
+
             const quickContainer = document.createElement('div');
             quickContainer.className = 'symplissime-quick-messages';
             
@@ -834,10 +835,14 @@
                 const btn = document.createElement('button');
                 btn.className = 'symplissime-quick-message';
                 btn.textContent = message;
+
+                const container = quickContainer;
                 btn.addEventListener('click', () => {
                     this.input.value = message;
                     this.sendMessage();
+                    container.remove();
                 });
+
                 quickContainer.appendChild(btn);
             });
             


### PR DESCRIPTION
## Summary
- Capture quick message container within listener and remove it after sending
- Prevent duplicate quick message containers by skipping `addQuickMessages` when one exists

## Testing
- `node --check symplissime-widget.js`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68af67785f4c832cbc7e2d92acb8a6b6