### PR TITLE
fix: await theme loading before initialization

### DIFF
--- a/symplissime-widget.js
+++ b/symplissime-widget.js
@@ -748,9 +748,9 @@
             this.unreadCount = 0;
             this.history = [];
 
-            themesLoaded.then(() => this.init());
+            this.init();
         }
-        
+
         getConfig(element) {
             return {
                 apiEndpoint: element.dataset.apiEndpoint || 'symplissime-widget-api.php',
@@ -781,7 +781,8 @@
             };
         }
         
-        init() {
+        async init() {
+            await themesLoaded;
             this.injectStyles();
             this.applyTheme();
             this.createWidget();


### PR DESCRIPTION
## Summary
- ensure widget waits for theme load before initialization to avoid race conditions

## Testing
- `npm test` (fails: Could not read package.json)

------
https://chatgpt.com/codex/tasks/task_e_68af788c5b58832cbaa7536643ee45a2