### PR TITLE
Refactor widget snippet generation

### DIFF
--- a/generate_snippet.php
+++ b/generate_snippet.php
@@ -1,0 +1,36 @@
+<?php
+require_once __DIR__ . '/snippet.php';
+
+$config = [
+    'attributes' => [
+        'api_endpoint' => $_POST['api_endpoint'] ?? 'symplissime-widget-api.php',
+        'workspace' => $_POST['workspace'] ?? '',
+        'title' => $_POST['title'] ?? '',
+        'auto_open' => isset($_POST['auto_open']),
+        'position' => $_POST['position'] ?? 'bottom-right',
+        'theme' => $_POST['theme'] ?? 'symplissime',
+        'accent_color' => $_POST['accent_color'] ?? '#48bb78',
+        'font_family' => $_POST['font_family'] ?? 'default',
+        'quick_messages' => $_POST['quick_messages'] ?? '',
+    ],
+    'greetings' => [
+        'welcome_message' => $_POST['welcome_message'] ?? '',
+        'display_mode' => $_POST['display_mode'] ?? 'bubble_immediate',
+        'display_delay' => isset($_POST['display_delay']) ? (int)$_POST['display_delay'] : 0,
+    ],
+    'general' => [
+        'display_name' => trim(preg_replace('/\s+/', ' ', $_POST['display_name'] ?? '')),
+        'profile_picture' => $_POST['profile_picture'] ?? '',
+        'bubble_icon' => isset($_POST['bubble_icon']),
+        'bubble_position' => $_POST['bubble_position'] ?? 'right',
+        'send_history_email' => isset($_POST['send_history_email']),
+        'owner_email' => $_POST['owner_email'] ?? '',
+        'footer_enabled' => isset($_POST['footer_enabled']),
+        'footer_text' => $_POST['footer_text'] ?? '',
+        'language' => $_POST['language'] ?? 'fr',
+        'time_zone' => $_POST['time_zone'] ?? 'Europe/Paris',
+    ],
+];
+
+header('Content-Type: text/plain; charset=UTF-8');
+echo renderSnippet($config);

--- a/snippet.php
+++ b/snippet.php
@@ -1,0 +1,55 @@
+<?php
+function renderSnippet(array $config): string {
+    $welcome = str_replace("\n", '&#10;', $config['greetings']['welcome_message']);
+    $welcome = htmlspecialchars($welcome, ENT_QUOTES);
+    $quick = str_replace("\n", '|', $config['attributes']['quick_messages']);
+    $quick = htmlspecialchars($quick, ENT_QUOTES);
+    $api = htmlspecialchars($config['attributes']['api_endpoint'], ENT_QUOTES);
+    $workspace = htmlspecialchars($config['attributes']['workspace'], ENT_QUOTES);
+    $title = htmlspecialchars($config['attributes']['title'], ENT_QUOTES);
+    $greetingMode = htmlspecialchars($config['greetings']['display_mode'], ENT_QUOTES);
+    $greetingDelay = htmlspecialchars($config['greetings']['display_delay'], ENT_QUOTES);
+    $autoOpen = $config['attributes']['auto_open'] ? 'true' : 'false';
+    $position = htmlspecialchars($config['attributes']['position'], ENT_QUOTES);
+    $theme = htmlspecialchars($config['attributes']['theme'], ENT_QUOTES);
+    $accentColor = htmlspecialchars($config['attributes']['accent_color'], ENT_QUOTES);
+    $font = htmlspecialchars($config['attributes']['font_family'], ENT_QUOTES);
+    $displayName = htmlspecialchars($config['general']['display_name'], ENT_QUOTES);
+    $profilePicture = htmlspecialchars($config['general']['profile_picture'], ENT_QUOTES);
+    $bubbleIcon = $config['general']['bubble_icon'] ? 'true' : 'false';
+    $bubblePosition = htmlspecialchars($config['general']['bubble_position'], ENT_QUOTES);
+    $sendHistoryEmail = $config['general']['send_history_email'] ? 'true' : 'false';
+    $ownerEmail = htmlspecialchars($config['general']['owner_email'], ENT_QUOTES);
+    $footerEnabled = $config['general']['footer_enabled'] ? 'true' : 'false';
+    $footerText = htmlspecialchars($config['general']['footer_text'], ENT_QUOTES);
+    $language = htmlspecialchars($config['general']['language'], ENT_QUOTES);
+    $timeZone = htmlspecialchars($config['general']['time_zone'], ENT_QUOTES);
+    return <<<HTML
+<script src="symplissime-widget.js"></script>
+<div class="symplissime-chat-widget"
+     data-api-endpoint="$api"
+     data-workspace="$workspace"
+     data-title="$title"
+     data-welcome-message="$welcome"
+     data-quick-messages="$quick"
+     data-greeting-mode="$greetingMode"
+     data-greeting-delay="$greetingDelay"
+     data-auto-open="$autoOpen"
+     data-position="$position"
+     data-theme="$theme"
+     data-accent-color="$accentColor"
+     data-font="$font"
+     data-display-name="$displayName"
+     data-profile-picture="$profilePicture"
+     data-bubble-icon="$bubbleIcon"
+     data-bubble-position="$bubblePosition"
+     data-send-history-email="$sendHistoryEmail"
+     data-owner-email="$ownerEmail"
+     data-footer-enabled="$footerEnabled"
+     data-footer-text="$footerText"
+     data-language="$language"
+     data-time-zone="$timeZone"
+></div>
+HTML;
+}
+?>


### PR DESCRIPTION
## Summary
- Move widget snippet generation into PHP `renderSnippet` template
- Expose new `generate_snippet.php` endpoint for AJAX regeneration
- Update config UI to call PHP endpoint instead of duplicating snippet logic in JS

## Testing
- `php -l snippet.php`
- `php -l generate_snippet.php`
- `php -l widgetconfig.php`
- `php generate_snippet.php | head -n 20`


------
https://chatgpt.com/codex/tasks/task_e_68af7fa5d07c832cb83ffcd162e96d12