### PR TITLE
add feature detection and fallbacks

### DIFF
--- a/widgetconfig.php
+++ b/widgetconfig.php
@@ -219,9 +219,16 @@ $snippet = renderSnippet($config);
             padding: 0 5px;
         }
         .theme-inputs {
-            display: grid;
-            grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+            display: flex;
+            flex-wrap: wrap;
             gap: 10px;
+        }
+
+        @supports (display: grid) {
+            .theme-inputs {
+                display: grid;
+                grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+            }
         }
         .theme-inputs label {
             display: flex;
@@ -462,7 +469,7 @@ $snippet = renderSnippet($config);
 
       function updateSnippet() {
         const data = new FormData(form);
-        fetch("generate_snippet.php", { method: "POST", body: data })
+        SymplissimeWidget.fetch("generate_snippet.php", { method: "POST", body: data })
             .then(r => r.text())
             .then(text => { document.getElementById("snippet").value = text; });
       }


### PR DESCRIPTION
## Summary
- add utility methods to detect browser features and provide fetch polyfill
- guard MutationObserver usage with feature detection
- use flexbox when CSS Grid is unavailable and employ custom fetch in config script

## Testing
- `node --check symplissime-widget.js`
- `php -l widgetconfig.php`
- `npm test` *(fails: missing package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68af8278e678832cbc49d08eefacec25