### PR TITLE
Persist chat widget session id

### DIFF
--- a/symplissime-widget.js
+++ b/symplissime-widget.js
@@ -10,6 +10,7 @@
 
     const SymplissimeWidgetNS = {};
     const widgetInstances = new WeakMap();
+    const SESSION_STORAGE_KEY = 'symplissime_widget_session_id';
 
     function decodeHTML(str) {
         const txt = document.createElement('textarea');
@@ -888,7 +889,11 @@
             this.stateLock = false;
             this.pendingState = null;
             this.stateTimeout = null;
-            this.sessionId = null; // sera fourni par le serveur
+            try {
+                this.sessionId = localStorage.getItem(SESSION_STORAGE_KEY) || null;
+            } catch (e) {
+                this.sessionId = null;
+            }
             this.unreadCount = 0;
             this.history = [];
 
@@ -1440,6 +1445,9 @@
                 const data = await response.json();
                 if (data.sessionId) {
                     this.sessionId = data.sessionId;
+                    try {
+                        localStorage.setItem(SESSION_STORAGE_KEY, this.sessionId);
+                    } catch (e) { /* ignore */ }
                 }
                 this.hideTyping();
                 


### PR DESCRIPTION
## Summary
- store session id in localStorage and reuse it on startup
- save new session ids returned by the API to keep conversation continuity

## Testing
- `npm test` *(fails: missing package.json)*
- `node --check symplissime-widget.js`

------
https://chatgpt.com/codex/tasks/task_e_68af8470348c832c95d3b5644ab4d459