### PR TITLE
feat: load themes from json with fallback

### DIFF
--- a/symplissime-widget.js
+++ b/symplissime-widget.js
@@ -122,82 +122,19 @@
     // Thèmes chargés dynamiquement depuis un fichier JSON
     const SymplissimeThemes = {
         cache: {},
-        defaults: {
-            symplissime: {
-                name: 'Symplissime Classic',
-                primary: '#48bb78',
-                primaryHover: '#38a169',
-                primaryLight: '#c6f6d5',
-                primaryDark: '#2f855a',
-                success: '#48bb78',
-                background: '#ffffff',
-                backgroundSecondary: '#f7fafc',
-                text: '#1a202c',
-                textSecondary: '#718096',
-                border: '#e2e8f0',
-                shadow: '0 4px 20px rgba(72, 187, 120, 0.15)'
-            },
-            professional: {
-                name: 'Professional Blue',
-                primary: '#4299e1',
-                primaryHover: '#3182ce',
-                primaryLight: '#bee3f8',
-                primaryDark: '#2c5aa0',
-                success: '#48bb78',
-                background: '#ffffff',
-                backgroundSecondary: '#f7fafc',
-                text: '#1a202c',
-                textSecondary: '#718096',
-                border: '#e2e8f0',
-                shadow: '0 4px 20px rgba(66, 153, 225, 0.15)'
-            },
-            modern: {
-                name: 'Modern Purple',
-                primary: '#9f7aea',
-                primaryHover: '#805ad5',
-                primaryLight: '#e9d8fd',
-                primaryDark: '#6b46c1',
-                success: '#48bb78',
-                background: '#ffffff',
-                backgroundSecondary: '#f7fafc',
-                text: '#1a202c',
-                textSecondary: '#718096',
-                border: '#e2e8f0',
-                shadow: '0 4px 20px rgba(159, 122, 234, 0.15)'
-            },
-            elegant: {
-                name: 'Elegant Dark',
-                primary: '#4a5568',
-                primaryHover: '#2d3748',
-                primaryLight: '#e2e8f0',
-                primaryDark: '#1a202c',
-                success: '#48bb78',
-                background: '#1a202c',
-                backgroundSecondary: '#2d3748',
-                text: '#f7fafc',
-                textSecondary: '#a0aec0',
-                border: '#4a5568',
-                shadow: '0 4px 20px rgba(74, 85, 104, 0.3)'
-            },
-            minimal: {
-                name: 'Minimal Gray',
-                primary: '#a0aec0',
-                primaryHover: '#718096',
-                primaryLight: '#f7fafc',
-                primaryDark: '#4a5568',
-                success: '#48bb78',
-                background: '#ffffff',
-                backgroundSecondary: '#f7fafc',
-                text: '#1a202c',
-                textSecondary: '#718096',
-                border: '#e2e8f0',
-                shadow: '0 4px 20px rgba(160, 174, 192, 0.15)'
-            }
-        },
-        minimal: {
-            name: 'Minimal Gray',
+        fallback: {
+            name: 'Symplissime Classic',
             primary: '#48bb78',
-            background: '#ffffff'
+            primaryHover: '#38a169',
+            primaryLight: '#c6f6d5',
+            primaryDark: '#2f855a',
+            success: '#48bb78',
+            background: '#ffffff',
+            backgroundSecondary: '#f7fafc',
+            text: '#1a202c',
+            textSecondary: '#718096',
+            border: '#e2e8f0',
+            shadow: '0 4px 20px rgba(72, 187, 120, 0.15)'
         },
         async load() {
             const CACHE_KEY = 'symplissime_widget_themes_v1';
@@ -250,7 +187,7 @@
                 throw new Error('Données de thèmes invalides');
             } catch (err) {
                 console.error('Erreur de chargement des thèmes:', err);
-                this.cache = { ...this.defaults };
+                this.cache = { symplissime: this.fallback };
                 try {
                     localStorage.setItem(
                         CACHE_KEY,
@@ -258,9 +195,6 @@
                     );
                 } catch (e) {
                     /* ignore cache errors */
-                }
-                if (!this.cache || Object.keys(this.cache).length === 0) {
-                    this.cache = { minimal: this.minimal };
                 }
             } finally {
                 clearTimeout(timeout);


### PR DESCRIPTION
## Summary
- remove built-in theme defaults and load themes from widget-themes.json
- add minimal built-in theme as fallback when theme fetch fails

## Testing
- `node --check symplissime-widget.js`


------
https://chatgpt.com/codex/tasks/task_e_68af91c15054832c8780e1278e22e3ed