### PR TITLE
fix: prevent auto-closing widget

### DIFF
--- a/symplissime-widget.js
+++ b/symplissime-widget.js
@@ -1187,7 +1187,9 @@
 
         changeState(newState) {
             clearTimeout(this.stateTimeout);
-            this.stateTimeout = setTimeout(() => this.forceState('closed'), 3000);
+            if (newState === 'closed') {
+                this.stateTimeout = setTimeout(() => this.forceState('closed'), 3000);
+            }
 
             const transitioned = this.state.transition(newState, () => {
                 switch (newState) {


### PR DESCRIPTION
## Summary
- avoid automatically closing widget after any state change

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b0117c7794832ca3903ce4419505d1