### PR TITLE
fix: load themes from JSON in admin script

### DIFF
--- a/assets/admin.js
+++ b/assets/admin.js
@@ -1,5 +1,5 @@
-    (function() {
-        const THEMES = <?php echo json_encode($themes, JSON_UNESCAPED_UNICODE); ?>;
+    (async function() {
+        const THEMES = await fetch('widget-themes.json').then(r => r.json());
         window.WidgetConfig = { getThemes: () => THEMES };
         const tabs = document.querySelectorAll('.tablink');
     const contents = document.querySelectorAll('.tabcontent');


### PR DESCRIPTION
## Summary
- fetch widget theme definitions from `widget-themes.json`
- run admin script initialization after loading themes

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b02388e370832c84c7fd0db646ac1d